### PR TITLE
semicolon over comma

### DIFF
--- a/oracle/app.py
+++ b/oracle/app.py
@@ -113,7 +113,7 @@ def gen_memos(raw_results_named) -> List[Memo]:
         memos.append(
             Memo(
                 memo_data=hexlify(
-                    ",".join(map(lambda v: f"{v:.5f}", values)).encode("utf-8")
+                    ";".join(map(lambda v: f"{v:.5f}", values)).encode("utf-8")
                 ).decode(),
                 memo_format=hexlify("text/csv".encode("utf-8")).decode(),
                 memo_type=hexlify(f"rates:{exchange.upper()}".encode("utf-8")).decode(),


### PR DESCRIPTION
match csv delimiter of semicolon.


i think this makes sense if an aggregate of currencies where some use commas like the EUR ( € 10  € 10,10  € 10 000,10)

[_another wise decision from Wietse_](
https://github.com/XRPL-Labs/XRPL-Persist-Price-Oracle/blob/4d155106e000ebcc5fd32ec0961a9d68dd3dd0e5/src/index.js#L30
)

https://www.quora.com/How-do-you-write-sums-of-euros-over-1-000-i-e-where-do-you-put-the-full-stops-and-the-commas


this also has the added benefit of matching the serialization of the XUMM oracle.

