### PR TITLE
add concurrency to gh-action workflows of mainnet and testnet

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-deploy:
+    concurrency: mainnet
     environment:
       name: mainnet
       url: https://explorer.xrplf.org/rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build-deploy:
+    concurrency: testnet
     environment: 
       name: testnet
       url: https://explorer-testnet.xrplf.org/rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN


### PR DESCRIPTION
add concurrency for 1 pending job at a time (~~remove cancels that look like errors from action log~~)

- it worked, with red boxes but with an explained error
  - ![image](https://user-images.githubusercontent.com/134478/129307311-1221e80c-c16f-44d7-aaca-cc4d67401b56.png)
  - ![image](https://user-images.githubusercontent.com/134478/129307369-d91aad90-0236-4a36-b8d1-380b2cd1ef2d.png)

