### PR TITLE
xrp-price-aggregate@0.0.10

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -1,2 +1,2 @@
-xrp-price-aggregate==0.0.9
+xrp-price-aggregate==0.0.10
 xrpl-py


### PR DESCRIPTION
[xrp-price-aggregate](https://github.com/yyolk/xrp-price-aggregate) also includes data [this oracle persists](https://github.com/yyolk/xrp-price-aggregate/pull/9). this may smooth out wrinkles in the noise or skew it. let's see how it goes! this may go directly to mainnet rather swiftly. with the aggregate's filtering there's little chance very skewed results would ever make it in compared to the amount of data being provided from other sources.