### PR TITLE
Cloudwatch custom put metric data

### DIFF
--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -21,9 +21,7 @@ jobs:
       XRPL_NODE_JSON_RPC_URL: https://s.altnet.rippletest.net:51234
       XRPL_NODE_ENVIRONMENT: Testnet
       STACK_NAME: xrpl-price-oracle-sam-test
-      # SCHEDULE_INTERVAL: 5
-      # TODO: temporary 1 minute for matching results in mainnet
-      SCHEDULE_INTERVAL: 1
+      SCHEDULE_INTERVAL: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -21,7 +21,9 @@ jobs:
       XRPL_NODE_JSON_RPC_URL: https://s.altnet.rippletest.net:51234
       XRPL_NODE_ENVIRONMENT: Testnet
       STACK_NAME: xrpl-price-oracle-sam-test
-      SCHEDULE_INTERVAL: 5
+      # SCHEDULE_INTERVAL: 5
+      # TODO: temporary 1 minute for matching results in mainnet
+      SCHEDULE_INTERVAL: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -208,7 +208,9 @@ def handler(
             price_USD_metric.put_data(
                 MetricData=[{
                     "MetricName": price_USD_metric.name,
-                    "Value": float(oracle_concluded_price)
+                    "Value": float(oracle_concluded_price),
+                    "Unit": "USD",
+                    "StorageResolution": 1,
                 }]
             )
             # price_USD_metric.put_data(Value=float(oracle_concluded_price))

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -209,6 +209,7 @@ def handler(
                 MetricData=[{
                     "MetricName": price_USD_metric.name,
                     "Value": float(oracle_concluded_price),
+                    "StorageResolution": 1,
                 }]
             )
             # price_USD_metric.put_data(Value=float(oracle_concluded_price))

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -205,10 +205,13 @@ def handler(
                 xrp_agg["filtered_median"],
                 ripple_time_to_datetime(tx_response.result["date"]),
             )
-            # price_USD_metric.put_data(
-            #     MetricData=[{"Value": float(oracle_concluded_price)}]
-            # )
-            price_USD_metric.put_data(Value=float(oracle_concluded_price))
+            price_USD_metric.put_data(
+                MetricData=[{
+                    "MetricName": price_USD_metric.name,
+                    "Value": float(oracle_concluded_price)
+                }]
+            )
+            # price_USD_metric.put_data(Value=float(oracle_concluded_price))
         else:
             # NOTE: if the submission errored, we could raise an exception
             #       instead of just logger.error(...)

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -209,7 +209,6 @@ def handler(
                 MetricData=[{
                     "MetricName": price_USD_metric.name,
                     "Value": float(oracle_concluded_price),
-                    "Unit": "USD",
                     "StorageResolution": 1,
                 }]
             )

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -39,12 +39,18 @@ logger.setLevel(logging.INFO)
 xrpl_client = JsonRpcClient(XRPL_JSON_RPC_URL)
 wallet = Wallet(seed=WALLET_SECRET, sequence=None)
 base_fee = get_fee(xrpl_client)
+# i like to use the service resource if its available
+cloudwatch = boto3.resource("cloudwatch")
+price_USD_metric = cloudwatch.Metric(
+    f"xrpl/${'mainnet' if MAINNET else 'testnet'}/oracle", "price_USD"
+)
 
 
 class FailedExecutionWillRetry(Exception):
     """Raise when you want to retry
     Defer to execution environment to limit retry executions.
     """
+
     pass
 
 
@@ -160,6 +166,8 @@ def handler(
 
     logger.debug("xrp_agg is %s", xrp_agg)
 
+    oracle_concluded_price = xrp_agg["filtered_median"]
+
     current_validated_ledger = get_latest_validated_ledger_sequence(client=xrpl_client)
     wallet.sequence = get_next_valid_seq_number(wallet.classic_address, xrpl_client)
 
@@ -171,7 +179,7 @@ def handler(
     memos.append(gen_memo(GIT_COMMIT, "text/plain", "oracle:GITSHA"))
 
     # Generate the IssuedCurrencyAmount with the provided value
-    iou_amount: IssuedCurrencyAmount = gen_iou_amount(str(xrp_agg["filtered_median"]))
+    iou_amount: IssuedCurrencyAmount = gen_iou_amount(str(oracle_concluded_price))
 
     # Create the transaction, we're doing a TrustSet
     trustset_tx = TrustSet(
@@ -197,6 +205,7 @@ def handler(
                 xrp_agg["filtered_median"],
                 ripple_time_to_datetime(tx_response.result["date"]),
             )
+            price_USD_metric.put_data(float(oracle_concluded_price ))
         else:
             # NOTE: if the submission errored, we could raise an exception
             #       instead of just logger.error(...)
@@ -209,7 +218,7 @@ def handler(
         if str(err).startswith("Transaction failed, tefPAST_SEQ"):
             # we should retry, we didn't match our expected SLA
             logger.error("we got a failed transaction past our expected SLA")
-            return
+            raise FailedExecutionWillRetry("We didn't meet our optimistic 4 ledger SLA")
         if str(err).startswith("Transaction failed, terQUEUED"):
             # our txn will send, this is fine?
             logger.info("Our txn send reliable submission failed with terQUEUED")
@@ -224,8 +233,8 @@ def handler(
     except JSONDecodeError as err:
         logger.error(
             (
-                "Got a JSONDecodeError %s, retrying the transaction by"
-                " failing this execution"
+                "Got a JSONDecodeError of '%s'."
+                " Retrying the transaction by failing this execution."
             ),
             err,
         )

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -8,6 +8,7 @@ from binascii import hexlify
 from json import JSONDecodeError
 from typing import List
 
+import boto3
 import xrp_price_aggregate
 
 from xrpl.account import get_next_valid_seq_number

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -205,7 +205,9 @@ def handler(
                 xrp_agg["filtered_median"],
                 ripple_time_to_datetime(tx_response.result["date"]),
             )
-            price_USD_metric.put_data(float(oracle_concluded_price ))
+            price_USD_metric.put_data(
+                MetricData=[{"Value": float(oracle_concluded_price)}]
+            )
         else:
             # NOTE: if the submission errored, we could raise an exception
             #       instead of just logger.error(...)

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -205,9 +205,10 @@ def handler(
                 xrp_agg["filtered_median"],
                 ripple_time_to_datetime(tx_response.result["date"]),
             )
-            price_USD_metric.put_data(
-                MetricData=[{"Value": float(oracle_concluded_price)}]
-            )
+            # price_USD_metric.put_data(
+            #     MetricData=[{"Value": float(oracle_concluded_price)}]
+            # )
+            price_USD_metric.put_data(Value=float(oracle_concluded_price))
         else:
             # NOTE: if the submission errored, we could raise an exception
             #       instead of just logger.error(...)

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -209,7 +209,6 @@ def handler(
                 MetricData=[{
                     "MetricName": price_USD_metric.name,
                     "Value": float(oracle_concluded_price),
-                    "StorageResolution": 1,
                 }]
             )
             # price_USD_metric.put_data(Value=float(oracle_concluded_price))

--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -42,7 +42,7 @@ base_fee = get_fee(xrpl_client)
 # i like to use the service resource if its available
 cloudwatch = boto3.resource("cloudwatch")
 price_USD_metric = cloudwatch.Metric(
-    f"xrpl/${'mainnet' if MAINNET else 'testnet'}/oracle", "price_USD"
+    f"xrpl/{'mainnet' if MAINNET else 'testnet'}/oracle", "price_USD"
 )
 
 

--- a/template.yaml
+++ b/template.yaml
@@ -90,6 +90,8 @@ Resources:
               - !Sub "rate(${ScheduleInterval} minutes)"
             Description: The interval this function will be invoked
             Enabled: true
+      Policies:
+        - CloudwatchPutMetricPolicy
 
 Outputs:
   OracleFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -91,7 +91,7 @@ Resources:
             Description: The interval this function will be invoked
             Enabled: true
       Policies:
-        - CloudwatchPutMetricPolicy: {}
+        - CloudWatchPutMetricPolicy: {}
 
 Outputs:
   OracleFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -91,7 +91,7 @@ Resources:
             Description: The interval this function will be invoked
             Enabled: true
       Policies:
-        - CloudwatchPutMetricPolicy
+        - CloudwatchPutMetricPolicy: {}
 
 Outputs:
   OracleFunction:


### PR DESCRIPTION
- use a cw custom metric to also push the price, 10 are always free and i can take quick advantage of this for monitoring beyond execution result if i want (re; deciding handling terQUEUED)

![image](https://user-images.githubusercontent.com/134478/129504527-cce51974-ca9a-43b0-9b3e-3dc65f373e23.png)

works well. i'm pushing price data into cw

we're pushing precision per second, even though we should publish 1 metric per minute

- ![image](https://user-images.githubusercontent.com/134478/129504775-f294d369-a7ce-410b-9dfb-8389c7e0dd5a.png)
- ![image](https://user-images.githubusercontent.com/134478/129504869-18cd8e60-2b03-408a-b3bd-873c5b53bfef.png)

- ![image](https://user-images.githubusercontent.com/134478/129504743-5e28cf3d-5aac-4699-98b7-97372cf5b74a.png)
- ![image](https://user-images.githubusercontent.com/134478/129504894-926fa739-8097-4fd7-b1da-390081af738b.png)
