### PR TITLE
update xrp-price-aggregate@0.0.11

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -1,2 +1,2 @@
-xrp-price-aggregate==0.0.10
+xrp-price-aggregate==0.0.11
 xrpl-py


### PR DESCRIPTION
- see yyolk/xrp-price-aggregate#10
  - adds [threexrp.dev](https://threexrp.dev) price in aggregate
  - drops price from retrieval from xrpl for now