### PR TITLE
Cw metric graphic widget readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml) [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml)
 
+<div align="center">
+
+![price USD PT-3H](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line.png)
+
+![price USD PT-3H Mainnet & Testnet](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line_allnets.png)
+
+</div>
+
 This is a XRPL Oracle that publishes external data into the XRPL.
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 ![price USD PT-3H](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line.png)
 
+<details><summary> This shows the Testnet updates less frequently than the mainnet. </summary>
+
 ![price USD PT-3H Mainnet & Testnet](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line_allnets.png)
+
+</details>
 
 </div>
 

--- a/template.yaml
+++ b/template.yaml
@@ -92,6 +92,59 @@ Resources:
             Enabled: true
       Policies:
         - CloudWatchPutMetricPolicy: {}
+        - S3WritePolicy:
+            BucketName: !Ref CloudwatchMetricWidgetImageBucket
+
+  CloudwatchMetricWidgetImageBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: private
+
+  CloudwatchMetricWidgetOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: "For serving the current price graph in the project's README, with cache."
+
+  CloudwatchMetricWidgetDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Origins:
+        - DomainName: !GetAtt CloudwatchMetricWidgetImageBucket.DomainName
+          Id: !Sub "${CloudwatchMetricWidgetImageBucket}Origin"
+          S3OriginConfig:
+            OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudwatchMetricWidgetOriginAccessIdentity}"
+        Enabled: 'true'
+        Comment: Distribution for serving the graph on the project README
+        DefaultRootObject: index.html
+        # Aliases:
+        # - mysite.example.com
+        # - yoursite.example.com
+        DefaultCacheBehavior:
+          AllowedMethods:
+          - GET
+          - HEAD
+          - OPTIONS
+          TargetOriginId: !Sub "${CloudwatchMetricWidgetImageBucket}Origin"
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: none
+          # TrustedSigners:
+          # - 1234567890EX
+          # - 1234567891EX
+          ViewerProtocolPolicy: allow-all
+        PriceClass: PriceClass_100
+        # Restrictions:
+        #   GeoRestriction:
+        #     RestrictionType: whitelist
+        #     Locations:
+        #     - AQ
+        #     - CV
+        ViewerCertificate:
+          CloudFrontDefaultCertificate: 'true'
 
 Outputs:
   OracleFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -92,59 +92,6 @@ Resources:
             Enabled: true
       Policies:
         - CloudWatchPutMetricPolicy: {}
-        - S3WritePolicy:
-            BucketName: !Ref CloudwatchMetricWidgetImageBucket
-
-  CloudwatchMetricWidgetImageBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      AccessControl: private
-
-  CloudwatchMetricWidgetOriginAccessIdentity:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-    Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: "For serving the current price graph in the project's README, with cache."
-
-  CloudwatchMetricWidgetDistribution:
-    Type: AWS::CloudFront::Distribution
-    Properties:
-      DistributionConfig:
-        Origins:
-        - DomainName: !GetAtt CloudwatchMetricWidgetImageBucket.DomainName
-          Id: !Sub "${CloudwatchMetricWidgetImageBucket}Origin"
-          S3OriginConfig:
-            OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudwatchMetricWidgetOriginAccessIdentity}"
-        Enabled: 'true'
-        Comment: Distribution for serving the graph on the project README
-        DefaultRootObject: index.html
-        # Aliases:
-        # - mysite.example.com
-        # - yoursite.example.com
-        DefaultCacheBehavior:
-          AllowedMethods:
-          - GET
-          - HEAD
-          - OPTIONS
-          TargetOriginId: !Sub "${CloudwatchMetricWidgetImageBucket}Origin"
-          ForwardedValues:
-            QueryString: 'false'
-            Cookies:
-              Forward: none
-          # TrustedSigners:
-          # - 1234567890EX
-          # - 1234567891EX
-          ViewerProtocolPolicy: allow-all
-        PriceClass: PriceClass_100
-        # Restrictions:
-        #   GeoRestriction:
-        #     RestrictionType: whitelist
-        #     Locations:
-        #     - AQ
-        #     - CV
-        ViewerCertificate:
-          CloudFrontDefaultCertificate: 'true'
 
 Outputs:
   OracleFunction:


### PR DESCRIPTION
Adds the metric graphs to the README which are intelligently cached. Also a SAM deployment, this does cost a few pennies a year though.

https://github.com/yyolk/xrpl-price-persist-oracle-metrics

![price USD PT-3H](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line.png)
![price USD PT-3H Mainnet & Testnet](https://d1nfdw5fckjov0.cloudfront.net/price_pt3h_line_allnets.png)


![image](https://user-images.githubusercontent.com/134478/129816383-f84a7e56-d0b9-4b84-8511-e78380af1dad.png)
