### PR TITLE
make wallet addresses for each network more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # xrpl-price-persist-oracle-sam
 
-[![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml) [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml)
+## Mainnet
+
+💳: `rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU`
+[🧭][mainnet-account-xrplf]
+
+▶️: [![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml)
+
+
+## Testnet
+
+💳: `rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN`
+[🧭][testnet-account-xrplf]
+
+▶️: [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml)
+
+
+## Price via Oracle
 
 <div align="center">
 
@@ -145,4 +161,6 @@ There are many options! This is just a minimal example :)
 
 
 
+[mainnet-account-xrplf]: https://explorer.xrplf.org/rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU "rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU"
+[testnet-account-xrplf]: https://explorer-testnet.xrplf.org/rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN "rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN"
 [example-testnet-account]: https://testnet.xrpl.org/accounts/rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN "An example testnet account"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Mainnet
 
 💳: `rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU`
-[🧭][mainnet-account-xrplf]
+<kbd>[🧭][mainnet-account-xrplf]</kbd>
 
 ▶️: [![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml)
 
@@ -11,7 +11,7 @@
 ## Testnet
 
 💳: `rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN`
-[🧭][testnet-account-xrplf]
+<kbd>[🧭][testnet-account-xrplf]</kbd>
 
 ▶️: [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml)
 


### PR DESCRIPTION
closes #24 

These are the same addresses that this repository deploys to and are were always and will always be viewable by viewing the deployment of that gh-action run.

This is to further enforce the notion that this is a public (auditable) xrpl-contract and as a result of the setup in this particular methodology will provide more transparency and flexibility for how we think about "smart contracts".